### PR TITLE
Use ServerSocketTrait in naia_server.rs

### DIFF
--- a/server/src/naia_server.rs
+++ b/server/src/naia_server.rs
@@ -11,7 +11,7 @@ use ring::{hmac, rand};
 use slotmap::DenseSlotMap;
 
 use naia_server_socket::{
-    Config as SocketConfig, MessageSender, Packet, ServerSocket, SocketEvent,
+    Config as SocketConfig, MessageSender, Packet, ServerSocket, ServerSocketTrait, SocketEvent,
 };
 pub use naia_shared::{
     Config, Connection, Entity, EntityMutator, EntityType, Event, EventType, Instant, ManagerType,


### PR DESCRIPTION
Not sure of what's going on here, but adding this was necessary for the library to even compile on my machine.

Rust version: rustc 1.45.1 (c367798cf 2020-07-26)